### PR TITLE
removing devcon dependency

### DIFF
--- a/start_streaming.bat
+++ b/start_streaming.bat
@@ -21,8 +21,8 @@ IF "%USE_RTSS%"=="true" (
 )
 
 :: Enable the virtual display
-devcon enable "root\iddsampledriver"
-devcon enable "MONITOR\LNX0000"
+PNPUTIL /enable-device /deviceid "root\iddsampledriver"
+PNPUTIL /enable-device /deviceid "MONITOR\LNX0000"
 
 :: Wait for the virtual display to be ready
 timeout /t 3 /nobreak >nul

--- a/stop_streaming.bat
+++ b/stop_streaming.bat
@@ -24,8 +24,8 @@ IF "%USE_RTSS%"=="true" (
 )
 
 :: Disable the virtual display
-devcon disable "MONITOR\LNX0000"
-devcon disable "root\iddsampledriver"
+PNPUTIL /disable-device /deviceid "MONITOR\LNX0000"
+PNPUTIL /disable-device /deviceid "root\iddsampledriver"
 
 :: Wait for the virtual display to be disabled
 timeout /t 3 /nobreak >nul


### PR DESCRIPTION
By swapping 
"devcon enable" with "PNPUTIL /enable-device /deviceid", and "devcon disable" with "PNPUTIL /disable-device /deviceid", you can get rid of the vs dependency if I'm not mistaken.