### PR TITLE
Fix virtual monitor not toggling

### DIFF
--- a/start_streaming.bat
+++ b/start_streaming.bat
@@ -21,8 +21,7 @@ IF "%USE_RTSS%"=="true" (
 )
 
 :: Enable the virtual display
-PNPUTIL /enable-device /deviceid "root\iddsampledriver"
-PNPUTIL /enable-device /deviceid "MONITOR\LNX0000"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$device = Get-PnpDevice | Where-Object {$_.FriendlyName -eq 'Virtual Display Driver by MTT'}; if ($device) { Enable-PnpDevice -InstanceId $device.InstanceId -Confirm:$false }"
 
 :: Wait for the virtual display to be ready
 timeout /t 3 /nobreak >nul

--- a/stop_streaming.bat
+++ b/stop_streaming.bat
@@ -24,8 +24,7 @@ IF "%USE_RTSS%"=="true" (
 )
 
 :: Disable the virtual display
-PNPUTIL /disable-device /deviceid "MONITOR\LNX0000"
-PNPUTIL /disable-device /deviceid "root\iddsampledriver"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$device = Get-PnpDevice | Where-Object {$_.FriendlyName -eq 'Virtual Display Driver by MTT'}; if ($device) { Disable-PnpDevice -InstanceId $device.InstanceId -Confirm:$false }"
 
 :: Wait for the virtual display to be disabled
 timeout /t 3 /nobreak >nul


### PR DESCRIPTION
In reference to #6, where pnputil was not disabling the virtual monitor. This is due to the device ID being different, at least on Windows 10 22H2 (19045.5011).