### PR TITLE
Handle VDD error statuses

### DIFF
--- a/src/start_streaming.ps1
+++ b/src/start_streaming.ps1
@@ -53,6 +53,7 @@ $device = Get-PnpDevice | Where-Object {
 if ($device) {
     if ($device.Status -eq "Error") {
         Write-Output "Error: Virtual display device found but it has an error status. Exiting script."
+        Disable-PnpDevice -InstanceId $device.InstanceId -Confirm:$false
         exit
     }
     Enable-PnpDevice -InstanceId $device.InstanceId -Confirm:$false

--- a/src/start_streaming.ps1
+++ b/src/start_streaming.ps1
@@ -51,6 +51,10 @@ $device = Get-PnpDevice | Where-Object {
 
 # Enable the device if found; otherwise, stop the script
 if ($device) {
+    if ($device.Status -eq "Error") {
+        Write-Output "Error: Virtual display device found but it has an error status. Exiting script."
+        exit
+    }
     Enable-PnpDevice -InstanceId $device.InstanceId -Confirm:$false
     Write-Output "Enabled device: $($device.FriendlyName)"
 }


### PR DESCRIPTION
I've been reinstalling Windows and Sunshine, and whilst installing the latest VDD I came across this error.

![image](https://github.com/user-attachments/assets/c6a87b58-a1b0-4ae3-ae4b-c97b09b3567c)

Yet, despite the error, the start script ran anyway. So, I've added a couple of lines to accommodate for that.