### PR TITLE
scripts: dynamically locate tool executables in C:\Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Follow the links above for installation instructions if these are not yet set up
 
 ### Tools
 
-All required tools, except the virtual display driver, are bundled and available for download in the [binaries folder](bin/) for convenience. A malware scan result is included. Alternatively, you can download the tools manually from their official sources if preferred. **Note**: The tools **must** be placed in the `C:\Tools` folder for the scripts to function correctly.
+All required tools, except the virtual display driver, are bundled and available for download in the [binaries folder](bin/) for convenience. A malware scan result is included. Alternatively, you can download the tools manually from their official sources if preferred. **Note**: The tools **must** be placed within the `C:\Tools` directory. The scripts will automatically search `C:\Tools` and any of its subfolders to find the executables, meaning you can keep them organized in separate folders and retain their original versioned filenames (e.g., `gsynctoggle-1.1.0-x86_64.exe`).
 
 ### Required Tools
 

--- a/src/start_streaming.ps1
+++ b/src/start_streaming.ps1
@@ -109,48 +109,76 @@ else {
 # Wait for the virtual display to be ready
 Start-Sleep -Seconds 3
 
-# Set resolution using QRes
-$qresCmd = "C:\Tools\QRes\QRes.exe"
-$qresArgs = @("/X:$CLIENT_WIDTH", "/Y:$CLIENT_HEIGHT", "/R:$CLIENT_REFRESH")
-Write-Output "Setting resolution with QRes: $qresCmd $($qresArgs -join ' ')"
-if ($DEBUG -eq "true") { & $qresCmd @qresArgs } else { & $qresCmd @qresArgs > $null }
+# Helper function to dynamically find an executable with optional versioning in C:\Tools or its subdirectories
+function Get-ToolPath ($BaseName) {
+    # Search for the base name followed by anything, ending in .exe (e.g., "gsynctoggle*.exe")
+    $filter = "$BaseName*.exe"
+    
+    # Sort descending so if multiple versions exist, it attempts to grab the highest version first
+    $file = Get-ChildItem -Path "C:\Tools" -Filter $filter -Recurse -File -ErrorAction SilentlyContinue | 
+            Sort-Object Name -Descending | 
+            Select-Object -First 1
+
+    if ($file) {
+        return $file.FullName
+    } else {
+        Write-Warning "Could not find any executable matching '$filter' in C:\Tools or its subdirectories."
+        return $null
+    }
+}
+
+# Find and run QRes
+$qresCmd = Get-ToolPath "QRes"
+if ($qresCmd) {
+    $qresArgs = @("/X:$CLIENT_WIDTH", "/Y:$CLIENT_HEIGHT", "/R:$CLIENT_REFRESH")
+    Write-Output "Setting resolution with QRes: $qresCmd $($qresArgs -join ' ')"
+    if ($DEBUG -eq "true") { & $qresCmd @qresArgs } else { & $qresCmd @qresArgs > $null }
+}
 
 # Wait for the resolution to be set
 Start-Sleep -Seconds 2
 
 # Set HDR using HDRCmd
-$hdrCmd = "C:\Tools\HDRTray\HDRCmd"
-$hdrArgs = if ($CLIENT_HDR -eq "true") { "on" } else { "off" }
-Write-Output "Turning HDR $hdrArgs with HDRCmd: $hdrCmd $hdrArgs"
-& $hdrCmd $hdrArgs
+$hdrCmd = Get-ToolPath "HDRCmd"
+if ($hdrCmd) {
+    $hdrArgs = if ($CLIENT_HDR -eq "true") { "on" } else { "off" }
+    Write-Output "Turning HDR $hdrArgs with HDRCmd: $hdrCmd $hdrArgs"
+    & $hdrCmd $hdrArgs
+}
 
 # Turn off G-Sync using gsynctoggle
-$gsyncCmd = "C:\Tools\gsync-toggle\gsynctoggle"
-$gsyncArgs = "0"
-Write-Output "Turning off G-Sync: $gsyncCmd $gsyncArgs"
-& $gsyncCmd $gsyncArgs
+$gsyncCmd = Get-ToolPath "gsynctoggle"
+if ($gsyncCmd) {
+    $gsyncArgs = "0"
+    Write-Output "Turning off G-Sync: $gsyncCmd $gsyncArgs"
+    & $gsyncCmd $gsyncArgs
+}
 
 # Set FPS limit using frl-toggle
-$frlCmd = "C:\Tools\frl-toggle\frltoggle.exe"
-$frlArgs = "$LIMIT"
-Write-Output "Setting FPS limit with frl-toggle: $frlCmd $frlArgs"
-& $frlCmd $frlArgs
+$frlCmd = Get-ToolPath "frltoggle"
+if ($frlCmd) {
+    $frlArgs = "$LIMIT"
+    Write-Output "Setting FPS limit with frl-toggle: $frlCmd $frlArgs"
+    & $frlCmd $frlArgs
+}
 
 # Set FPS limiter and overlay using rtss-cli if RTSS is enabled
 if ($USE_RTSS -eq "true") {
-    $rtssLimitCmd = "C:\Tools\rtss-cli\rtss-cli.exe"
-    $rtssLimitArgs = "limit:set $LIMIT"
-    $rtssLimiterArgs = "limiter:set 0"
-    $rtssOverlayArgs = "overlay:set 1"
+    $rtssLimitCmd = Get-ToolPath "rtss-cli"
+    if ($rtssLimitCmd) {
+        $rtssLimitArgs = "limit:set $LIMIT"
+        $rtssLimiterArgs = "limiter:set 0"
+        $rtssOverlayArgs = "overlay:set 1"
 
-    Write-Output "Setting RTSS FPS limit: $rtssLimitCmd $rtssLimitArgs"
-    & $rtssLimitCmd $rtssLimitArgs
+        Write-Output "Setting RTSS FPS limit: $rtssLimitCmd $rtssLimitArgs"
+        & $rtssLimitCmd $rtssLimitArgs
 
-    Write-Output "Disabling RTSS limiter: $rtssLimitCmd $rtssLimiterArgs"
-    & $rtssLimitCmd $rtssLimiterArgs
+        Write-Output "Disabling RTSS limiter: $rtssLimitCmd $rtssLimiterArgs"
+        & $rtssLimitCmd $rtssLimiterArgs
 
-    Write-Output "Enabling RTSS overlay: $rtssLimitCmd $rtssOverlayArgs"
-    & $rtssLimitCmd $rtssOverlayArgs
+        Write-Output "Enabling RTSS overlay: $rtssLimitCmd $rtssOverlayArgs"
+        & $rtssLimitCmd $rtssOverlayArgs
+    }
 }
 
 # Wait to ensure all commands complete, or wait for user input if in debug mode

--- a/src/stop_streaming.ps1
+++ b/src/stop_streaming.ps1
@@ -103,48 +103,73 @@ else {
 # Wait for the virtual display to be disabled
 Start-Sleep -Seconds 3
 
+# Helper function to dynamically find an executable with optional versioning in C:\Tools or its subdirectories
+function Get-ToolPath ($BaseName) {
+    $filter = "$BaseName*.exe"
+    $file = Get-ChildItem -Path "C:\Tools" -Filter $filter -Recurse -File -ErrorAction SilentlyContinue | 
+            Sort-Object Name -Descending | 
+            Select-Object -First 1
+
+    if ($file) {
+        return $file.FullName
+    } else {
+        Write-Warning "Could not find any executable matching '$filter' in C:\Tools or its subdirectories."
+        return $null
+    }
+}
+
 # Set resolution using QRes
-$qresCmd = "C:\Tools\QRes\QRes.exe"
-$qresArgs = @("/X:$WIDTH", "/Y:$HEIGHT", "/R:$REFRESH")
-Write-Output "Setting resolution with QRes: $qresCmd $($qresArgs -join ' ')"
-if ($DEBUG -eq "true") { & $qresCmd @qresArgs } else { & $qresCmd @qresArgs > $null }
+$qresCmd = Get-ToolPath "QRes"
+if ($qresCmd) {
+    $qresArgs = @("/X:$WIDTH", "/Y:$HEIGHT", "/R:$REFRESH")
+    Write-Output "Setting resolution with QRes: $qresCmd $($qresArgs -join ' ')"
+    if ($DEBUG -eq "true") { & $qresCmd @qresArgs } else { & $qresCmd @qresArgs > $null }
+}
 
 # Wait for the resolution to be set
 Start-Sleep -Seconds 2
 
 # Set HDR using HDRCmd
-$hdrCmd = "C:\Tools\HDRTray\HDRCmd"
-$hdrArgs = if ($HDR -eq "true") { "on" } else { "off" }
-Write-Output "Turning HDR $hdrArgs with HDRCmd: $hdrCmd $hdrArgs"
-& $hdrCmd $hdrArgs
+$hdrCmd = Get-ToolPath "HDRCmd"
+if ($hdrCmd) {
+    $hdrArgs = if ($HDR -eq "true") { "on" } else { "off" }
+    Write-Output "Turning HDR $hdrArgs with HDRCmd: $hdrCmd $hdrArgs"
+    & $hdrCmd $hdrArgs
+}
 
 # Turn on G-Sync using gsynctoggle
-$gsyncCmd = "C:\Tools\gsync-toggle\gsynctoggle"
-$gsyncArgs = "1"
-Write-Output "Turning on G-Sync: $gsyncCmd $gsyncArgs"
-& $gsyncCmd $gsyncArgs
+$gsyncCmd = Get-ToolPath "gsynctoggle"
+if ($gsyncCmd) {
+    $gsyncArgs = "1"
+    Write-Output "Turning on G-Sync: $gsyncCmd $gsyncArgs"
+    & $gsyncCmd $gsyncArgs
+}
 
 # Set FPS limit using frl-toggle
-$frlCmd = "C:\Tools\frl-toggle\frltoggle.exe"
-$frlArgs = "$LIMIT"
-Write-Output "Setting FPS limit with frl-toggle: $frlCmd $frlArgs"
-& $frlCmd $frlArgs
+$frlCmd = Get-ToolPath "frltoggle"
+if ($frlCmd) {
+    $frlArgs = "$LIMIT"
+    Write-Output "Setting FPS limit with frl-toggle: $frlCmd $frlArgs"
+    & $frlCmd $frlArgs
+}
 
 # Set FPS limiter and overlay using rtss-cli if RTSS is enabled
 if ($USE_RTSS -eq "true") {
-    $rtssLimitCmd = "C:\Tools\rtss-cli\rtss-cli.exe"
-    $rtssLimitArgs = "limit:set $LIMIT"
-    $rtssLimiterArgs = "limiter:set 0"
-    $rtssOverlayArgs = "overlay:set 0"
+    $rtssLimitCmd = Get-ToolPath "rtss-cli"
+    if ($rtssLimitCmd) {
+        $rtssLimitArgs = "limit:set $LIMIT"
+        $rtssLimiterArgs = "limiter:set 0"
+        $rtssOverlayArgs = "overlay:set 0"
 
-    Write-Output "Setting RTSS FPS limit: $rtssLimitCmd $rtssLimitArgs"
-    & $rtssLimitCmd $rtssLimitArgs
+        Write-Output "Setting RTSS FPS limit: $rtssLimitCmd $rtssLimitArgs"
+        & $rtssLimitCmd $rtssLimitArgs
 
-    Write-Output "Disabling RTSS limiter: $rtssLimitCmd $rtssLimiterArgs"
-    & $rtssLimitCmd $rtssLimiterArgs
+        Write-Output "Disabling RTSS limiter: $rtssLimitCmd $rtssLimiterArgs"
+        & $rtssLimitCmd $rtssLimiterArgs
 
-    Write-Output "Disabling RTSS overlay: $rtssLimitCmd $rtssOverlayArgs"
-    & $rtssLimitCmd $rtssOverlayArgs
+        Write-Output "Disabling RTSS overlay: $rtssLimitCmd $rtssOverlayArgs"
+        & $rtssLimitCmd $rtssOverlayArgs
+    }
 }
 
 # Wait to ensure all commands complete, or wait for user input if in debug mode


### PR DESCRIPTION
Replaced hardcoded executable paths in the PowerShell scripts with a  `Get-ToolPath` helper function. The scripts now recursively search  the `C:\Tools` directory to find the required binaries.

This change provides better flexibility by:
- Allowing tools to be placed loosely in C:\Tools or organized inside subfolders.
- Supporting executables with version numbers or architecture suffixes  in their names (e.g., `gsynctoggle-1.1.0-x86_64.exe`).
- Automatically selecting the newest version (alphabetically descending)  if multiple versions of a tool are present.

The README has also been updated to document this new behavior.

Assisted-by: Gemini:gemini-3.1pro-preview